### PR TITLE
Use one space after emoji

### DIFF
--- a/gen_type_stubs.py
+++ b/gen_type_stubs.py
@@ -26,7 +26,7 @@ print(f"🔍 Found MNE-Python {mne.__version__} installation in {MNE_INSTALL_DIR
 
 STUBS_OUT_DIR = Path(__file__).parent / "typings"
 if STUBS_OUT_DIR.exists():
-    print(f"🪣 Found existing output directory, deleting: {STUBS_OUT_DIR}")
+    print(f"🪣  Found existing output directory, deleting: {STUBS_OUT_DIR}")
     shutil.rmtree(STUBS_OUT_DIR)
 
 print(f"💡 Will store the type stubs in: {STUBS_OUT_DIR}")

--- a/gen_type_stubs.py
+++ b/gen_type_stubs.py
@@ -26,10 +26,10 @@ print(f"🔍 Found MNE-Python {mne.__version__} installation in {MNE_INSTALL_DIR
 
 STUBS_OUT_DIR = Path(__file__).parent / "typings"
 if STUBS_OUT_DIR.exists():
-    print(f"🪣  Found existing output directory, deleting: {STUBS_OUT_DIR}")
+    print(f"🪣 Found existing output directory, deleting: {STUBS_OUT_DIR}")
     shutil.rmtree(STUBS_OUT_DIR)
 
-print(f"💡  Will store the type stubs in: {STUBS_OUT_DIR}")
+print(f"💡 Will store the type stubs in: {STUBS_OUT_DIR}")
 
 # Generate list of module paths we want to process
 # We first glob all modules, then drop all that were selected for exclusion


### PR DESCRIPTION
Just a minor cosmetic tweak, there should be only one space after an emoji for consistency.